### PR TITLE
Add Support For PIC 16F877

### DIFF
--- a/ProgramPIC/ProgramPIC.pde
+++ b/ProgramPIC/ProgramPIC.pde
@@ -103,6 +103,7 @@ const char s_pic16f883[]  PROGMEM = "pic16f883";
 const char s_pic16f884[]  PROGMEM = "pic16f884";
 const char s_pic16f886[]  PROGMEM = "pic16f886";
 const char s_pic16f887[]  PROGMEM = "pic16f887";
+const char s_pic16f877[] PROGMEM = "pic16f877";
 
 // List of devices that are currently supported and their properties.
 // Note: most of these are based on published information and have not
@@ -144,7 +145,7 @@ struct deviceInfo const devices[] PROGMEM = {
     {s_pic16f628,  0x07C0, 2048, 0x2000, 0x2100, 8, 128, 0, 0, FLASH,  EEPROM},
     {s_pic16f628a, 0x1060, 2048, 0x2000, 0x2100, 8, 128, 0, 0, FLASH4, EEPROM},
     {s_pic16f648a, 0x1100, 4096, 0x2000, 0x2100, 8, 256, 0, 0, FLASH4, EEPROM},
-
+    
     // http://ww1.microchip.com/downloads/en/DeviceDoc/41287D.pdf
     {s_pic16f882,  0x2000, 2048, 0x2000, 0x2100, 9, 128, 0, 0, FLASH4, EEPROM},
     {s_pic16f883,  0x2020, 4096, 0x2000, 0x2100, 9, 256, 0, 0, FLASH4, EEPROM},
@@ -152,6 +153,9 @@ struct deviceInfo const devices[] PROGMEM = {
     {s_pic16f886,  0x2060, 8192, 0x2000, 0x2100, 9, 256, 0, 0, FLASH4, EEPROM},
     {s_pic16f887,  0x2080, 8192, 0x2000, 0x2100, 9, 256, 0, 0, FLASH4, EEPROM},
 
+    // http://ww1.microchip.com/downloads/en/DeviceDoc/39025f.pdf
+    {s_pic16f877, 0x09A0, 8192, 0x2000, 0x2100, 8, 256, 0, 0, FLASH4, EEPROM },
+    
     {0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 };
 


### PR DESCRIPTION
I've added chipset data for the 16F877 that someone else may find useful. 

I've had one of these lying around for years not doing anything, but now I can actually make use of it!

As a side note I have a [develop branch](https://github.com/alchemycs/ardpicprog/tree/develop) in my fork that fixes up your reference to `Plang` to `ardpicprog` as well as some notes on the 16f877 and the current draw. I left them out of this pull request in case you wanted to deal with it some other way.

Also I wanted to say thanks for the work you have done on this project!
